### PR TITLE
Copyright date update

### DIFF
--- a/about.html
+++ b/about.html
@@ -208,7 +208,7 @@
     <div class="row">
       <div class="col-md-12 col-xs-12" style="background-color:#1b1b1b;padding-top:10px;">
         <p class="text-center" style="color:#a7a7a7;">Last Updated: Feb 2023 | Version 3.5.0</p>
-        <p class="text-muted text-center">Website/ Images &copy; MichaelKulbacki.com 2023</p>
+        <p class="text-muted text-center">Website/ Images &copy; MichaelKulbacki.com <span id="copyright-year"></span></p>
       </div>
     </div>
   </div>
@@ -276,7 +276,7 @@
       });
     });
   </script>
-
+  <script src="js/copyright.js"></script>
 </body>
 
 </html>

--- a/contact.html
+++ b/contact.html
@@ -218,7 +218,7 @@
     <div class="row">
       <div class="col-md-12 col-xs-12" style="background-color:#1b1b1b;padding-top:10px;">
         <p class="text-center" style="color:#a7a7a7;">Last Updated: Feb 2023 | Version 3.5.0</p>
-        <p class="text-muted text-center">Website/ Images &copy; MichaelKulbacki.com 2023</p>
+        <p class="text-muted text-center">Website/ Images &copy; MichaelKulbacki.com <span id="copyright-year"></span></p>
       </div>
     </div>
   </div>
@@ -286,7 +286,7 @@
       });
     });
   </script>
-
+  <script src="js/copyright.js"></script>
 </body>
 
 </html>

--- a/education.html
+++ b/education.html
@@ -268,7 +268,7 @@
     <div class="row">
       <div class="col-md-12 col-xs-12" style="background-color:#1b1b1b;padding-top:10px;">
         <p class="text-center" style="color:#a7a7a7;">Last Updated: Feb 2023 | Version 3.5.0</p>
-        <p class="text-muted text-center">Website/ Images &copy; MichaelKulbacki.com 2023</p>
+        <p class="text-muted text-center">Website/ Images &copy; MichaelKulbacki.com <span id="copyright-year"></span></p>
       </div>
     </div>
   </div>
@@ -336,7 +336,7 @@
       });
     });
   </script>
-
+  <script src="js/copyright.js"></script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -380,7 +380,7 @@
     <div class="row">
       <div class="col-md-12 col-xs-12" style="background-color:#1b1b1b;padding-top:10px;">
         <p class="text-center" style="color:#a7a7a7;">Last Updated: Feb 2023 | Version 3.5.0</p>
-        <p class="text-muted text-center">Website/ Images &copy; MichaelKulbacki.com 2023</p>
+        <p class="text-muted text-center">Website/ Images &copy; MichaelKulbacki.com <span id="copyright-year"></span></p>
       </div>
     </div>
   </div>
@@ -478,6 +478,7 @@
       });
     });
   </script>
+  <script src="js/copyright.js"></script>
 </body>
 
 </html>

--- a/js/copyright.js
+++ b/js/copyright.js
@@ -1,0 +1,3 @@
+document.addEventListener('DOMContentLoaded', function() {
+  document.getElementById('copyright-year').textContent = new Date().getFullYear();
+});

--- a/landscapes.html
+++ b/landscapes.html
@@ -290,7 +290,7 @@
     <div class="row">
       <div class="col-md-12 col-xs-12" style="background-color:#1b1b1b;padding-top:10px;">
         <p class="text-center" style="color:#a7a7a7;">Last Updated: Feb 2023 | Version 3.5.0</p>
-        <p class="text-muted text-center">Website/ Images &copy; MichaelKulbacki.com 2023</p>
+        <p class="text-muted text-center">Website/ Images &copy; MichaelKulbacki.com <span id="copyright-year"></span></p>
       </div>
     </div>
   </div>
@@ -390,7 +390,7 @@
       });
     });
   </script>
-
+  <script src="js/copyright.js"></script>
 </body>
 
 </html>

--- a/photoprojects.html
+++ b/photoprojects.html
@@ -238,7 +238,7 @@
     <div class="row">
       <div class="col-md-12 col-xs-12" style="background-color:#1b1b1b;padding-top:10px;">
         <p class="text-center" style="color:#a7a7a7;">Last Updated: Feb 2023 | Version 3.5.0</p>
-        <p class="text-muted text-center">Website/ Images &copy; MichaelKulbacki.com 2023</p>
+        <p class="text-muted text-center">Website/ Images &copy; MichaelKulbacki.com <span id="copyright-year"></span></p>
       </div>
     </div>
   </div>
@@ -330,6 +330,7 @@
       });
     });
   </script>
+  <script src="js/copyright.js"></script>
 </body>
 
 </html>

--- a/portraits.html
+++ b/portraits.html
@@ -275,7 +275,7 @@
     <div class="row">
       <div class="col-md-12 col-xs-12" style="background-color:#1b1b1b;padding-top:10px;">
         <p class="text-center" style="color:#a7a7a7;">Last Updated: Feb 2023 | Version 3.5.0</p>
-        <p class="text-muted text-center">Website/ Images &copy; MichaelKulbacki.com 2023</p>
+        <p class="text-muted text-center">Website/ Images &copy; MichaelKulbacki.com <span id="copyright-year"></span></p>
       </div>
     </div>
   </div>
@@ -367,6 +367,7 @@
       });
     });
   </script>
+  <script src="js/copyright.js"></script>
 </body>
 
 </html>

--- a/projects.html
+++ b/projects.html
@@ -366,7 +366,7 @@
     <div class="row">
       <div class="col-md-12 col-xs-12" style="background-color:#1b1b1b;padding-top:10px;">
         <p class="text-center" style="color:#a7a7a7;">Last Updated: Feb 2023 | Version 3.5.0</p>
-        <p class="text-muted text-center">Website/ Images &copy; MichaelKulbacki.com 2023</p>
+        <p class="text-muted text-center">Website/ Images &copy; MichaelKulbacki.com <span id="copyright-year"></span></p>
       </div>
     </div>
   </div>
@@ -434,7 +434,7 @@
       });
     });
   </script>
-
+  <script src="js/copyright.js"></script>
 </body>
 
 </html>

--- a/wedding.html
+++ b/wedding.html
@@ -374,7 +374,7 @@
     <div class="row">
       <div class="col-md-12 col-xs-12" style="background-color:#1b1b1b;padding-top:10px;">
         <p class="text-center" style="color:#a7a7a7;">Last Updated: Feb 2023 | Version 3.5.0</p>
-        <p class="text-muted text-center">Website/ Images &copy; MichaelKulbacki.com 2023</p>
+        <p class="text-muted text-center">Website/ Images &copy; MichaelKulbacki.com <span id="copyright-year"></span></p>
       </div>
     </div>
   </div>
@@ -472,6 +472,7 @@
       });
     });
   </script>
+  <script src="js/copyright.js"></script>
 </body>
 
 </html>

--- a/work.html
+++ b/work.html
@@ -489,7 +489,7 @@
     <div class="row">
       <div class="col-md-12 col-xs-12" style="background-color:#1b1b1b;padding-top:10px;">
         <p class="text-center" style="color:#a7a7a7;">Last Updated: Feb 2023 | Version 3.5.0</p>
-        <p class="text-muted text-center">Website/ Images &copy; MichaelKulbacki.com 2023</p>
+        <p class="text-muted text-center">Website/ Images &copy; MichaelKulbacki.com <span id="copyright-year"></span></p>
       </div>
     </div>
   </div>
@@ -556,7 +556,7 @@
       });
     });
   </script>
-
+  <script src="js/copyright.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION


- I added a JavaScript file `js/copyright.js` that will automatically set the copyright year to the current year.
- I modified all HTML files to use this script, replacing the hardcoded copyright year.
- This ensures the copyright year is always up-to-date and simplifies future maintenance for you.